### PR TITLE
[v1.3.5] New Command and minor fixes

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -16,8 +16,10 @@ public class Messages {
     public static final String MESSAGE_TIME_CLASH = "The tasks start time should not be before its end time if"
                                                  + " its' Start Date is the same as its End Date.";
     public static final String MESSAGE_INVALID_FILE_TYPE = "Invalid file type!";
-    public static final String MESSAGE_ONLY_GO_TO_MODE_COMMANDS = "This command can only be used in patient mode "
-                                                                + "to return to patient mode, use the back command";
+    public static final String MESSAGE_ONLY_GO_TO_MODE_COMMANDS = "This command can only be used in patient mode. "
+                                                                + "To return to patient mode, use the back command";
+    public static final String MESSAGE_ONLY_PATIENT_MODE_COMMANDS = "This command can only be used in GoTo mode. "
+                                                                + "To go to the GoTo mode, use the GoTo command";
     public static final String MESSAGE_ONLY_TASK_OR_DATE_COMMANDS = "This command cannot be ran here. Only task related"
                                                                 + " commands and dates should be enteredit com here.";
     public static final String MESSAGE_IN_GO_TO_MODE = "Please exit the goto mode using the back command first";

--- a/src/main/java/seedu/address/logic/commands/RecordAddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RecordAddCommand.java
@@ -26,6 +26,8 @@ public class RecordAddCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "New record added to %1$s";
 
+    public static final String MESSAGE_DUPLICATE_RECORD = "Record already exists, but is still added to %1$s!";
+
     public static final String MESSAGE_ERROR = "Please specify the patient using the goto command first";
 
     private final Patient toAdd;
@@ -41,6 +43,14 @@ public class RecordAddCommand extends Command {
         this.description = description;
     }
 
+    /**
+     * Executes the command.
+     * Note that duplicate records still get added. But a duplicate message is shown to user.
+     * @param model {@code Model} which the command should operate on.
+     * @param history {@code CommandHistory} which the command should operate on.
+     * @return the {@code CommandResult} of the command call.
+     * @throws CommandException the error message when the method is called in non-GoTo mode.
+     */
     @Override
     public CommandResult execute(Model model, CommandHistory history) throws CommandException {
         if (MainWindow.isGoToMode() && toAdd != null) {
@@ -49,7 +59,12 @@ public class RecordAddCommand extends Command {
             Record record = new Record(description);
             model.addRecord(record);
 
-            return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd.getName()));
+            if (model.hasRecord(record)) {
+                return new CommandResult(String.format(MESSAGE_DUPLICATE_RECORD, toAdd.getName()));
+            } else {
+                return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd.getName()));
+            }
+
         } else {
             throw new CommandException(MESSAGE_ERROR);
         }

--- a/src/main/java/seedu/address/logic/commands/RecordAddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RecordAddCommand.java
@@ -57,9 +57,11 @@ public class RecordAddCommand extends Command {
             requireNonNull(model);
 
             Record record = new Record(description);
+            boolean isDuplicate = model.hasRecord(record);
+
             model.addRecord(record);
 
-            if (model.hasRecord(record)) {
+            if (isDuplicate) {
                 return new CommandResult(String.format(MESSAGE_DUPLICATE_RECORD, toAdd.getName()));
             } else {
                 return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd.getName()));

--- a/src/main/java/seedu/address/logic/commands/RecordClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RecordClearCommand.java
@@ -1,0 +1,35 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.logic.CommandHistory;
+import seedu.address.model.Model;
+import seedu.address.model.patient.Patient;
+import seedu.address.ui.MainWindow;
+
+import java.util.ArrayList;
+
+/**
+ * Clears the record list of the specified patient.
+ * Should only be run in the GoTo mode.
+ */
+public class RecordClearCommand extends Command {
+
+    public static final String COMMAND_WORD = "recordclear";
+    public static final String MESSAGE_SUCCESS = "The dental record list of %1$s has been cleared!";
+
+    @Override
+    public CommandResult execute(Model model, CommandHistory history) {
+        requireNonNull(model);
+
+        Patient target = MainWindow.getRecordPatient();
+
+        Patient editedTarget = target.copy();
+        editedTarget.setRecords(new ArrayList<>());
+
+        MainWindow.setRecordPatient(editedTarget);
+        model.setPerson(target, editedTarget);
+
+        return new CommandResult(String.format(MESSAGE_SUCCESS, editedTarget.getName().fullName));
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/RecordClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RecordClearCommand.java
@@ -2,12 +2,12 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.ArrayList;
+
 import seedu.address.logic.CommandHistory;
 import seedu.address.model.Model;
 import seedu.address.model.patient.Patient;
 import seedu.address.ui.MainWindow;
-
-import java.util.ArrayList;
 
 /**
  * Clears the record list of the specified patient.

--- a/src/main/java/seedu/address/logic/commands/RecordDeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RecordDeleteCommand.java
@@ -42,7 +42,6 @@ public class RecordDeleteCommand extends Command {
 
         Record recordToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deleteRecord(recordToDelete);
-        model.commitAddressBook();
         return new CommandResult(String.format(MESSAGE_DELETE_RECORD_SUCCESS, recordToDelete.getRecord()));
     }
 

--- a/src/main/java/seedu/address/logic/commands/RecordEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RecordEditCommand.java
@@ -64,7 +64,6 @@ public class RecordEditCommand extends Command {
         }
 
         model.setRecord(recordToEdit, editedRecord);
-        model.commitAddressBook();
 
         return new CommandResult(String.format(MESSAGE_EDIT_RECORD_SUCCESS));
     }

--- a/src/main/java/seedu/address/logic/commands/TeethEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/TeethEditCommand.java
@@ -59,7 +59,6 @@ public class TeethEditCommand extends Command {
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         model.setSelectedPerson(null);
         model.setSelectedPerson(MainWindow.getRecordPatient());
-        model.commitAddressBook();
 
         return new CommandResult(String.format(MESSAGE_EDIT_TOOTH_SUCCESS));
     }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_ONLY_GO_TO_MODE_COMMANDS;
+import static seedu.address.commons.core.Messages.MESSAGE_ONLY_PATIENT_MODE_COMMANDS;
 import static seedu.address.commons.core.Messages.MESSAGE_ONLY_TASK_OR_DATE_COMMANDS;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 
@@ -26,6 +27,7 @@ import seedu.address.logic.commands.ImportCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.OpenCommand;
 import seedu.address.logic.commands.RecordAddCommand;
+import seedu.address.logic.commands.RecordClearCommand;
 import seedu.address.logic.commands.RecordDeleteCommand;
 import seedu.address.logic.commands.RecordEditCommand;
 import seedu.address.logic.commands.RedoCommand;
@@ -148,22 +150,32 @@ public class AddressBookParser {
 
         case BackCommand.COMMAND_WORD:
             checkSpecialCondition(!checkBothConditions);
+            assertGoToMode();
             return new BackCommand();
 
         case RecordAddCommand.COMMAND_WORD:
             checkSpecialCondition(!checkBothConditions);
+            assertGoToMode();
             return new RecordAddCommandParser().parse(arguments);
+
+        case RecordClearCommand.COMMAND_WORD:
+            checkSpecialCondition(!checkBothConditions);
+            assertGoToMode();
+            return new RecordClearCommand();
 
         case RecordEditCommand.COMMAND_WORD:
             checkSpecialCondition(!checkBothConditions);
+            assertGoToMode();
             return new RecordEditCommandParser().parse(arguments);
 
         case RecordDeleteCommand.COMMAND_WORD:
             checkSpecialCondition(!checkBothConditions);
+            assertGoToMode();
             return new RecordDeleteCommandParser().parse(arguments);
 
         case TeethEditCommand.COMMAND_WORD:
             checkSpecialCondition(!checkBothConditions);
+            assertGoToMode();
             return new TeethEditCommandParser().parse(arguments);
 
         //Commands that should run in ALL modes and popups
@@ -206,6 +218,15 @@ public class AddressBookParser {
         }
         if (MainWindow.isGoToMode() && checkBothConditions) {
             throw new ParseException(MESSAGE_ONLY_GO_TO_MODE_COMMANDS);
+        }
+    }
+
+    /**
+     * For commands which can only run in GoTo mode.
+     */
+    public void assertGoToMode() throws ParseException {
+        if (!MainWindow.isGoToMode()) {
+            throw new ParseException(MESSAGE_ONLY_PATIENT_MODE_COMMANDS);
         }
     }
 

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -88,6 +88,7 @@ public class AddressBook implements ReadOnlyAddressBook {
 
         setPersons(newData.getPersonList());
         setTasks(newData.getTaskList());
+        setRecords(newData.getRecordList());
     }
     //// task-level operations
 
@@ -198,8 +199,9 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void setPerson(Person target, Person editedPerson) {
         requireNonNull(editedPerson);
-
         persons.setPerson(target, editedPerson);
+
+        setRecords(((Patient) editedPerson).getRecords());
         indicateModified();
     }
 

--- a/src/main/java/seedu/address/model/record/UniqueRecordList.java
+++ b/src/main/java/seedu/address/model/record/UniqueRecordList.java
@@ -10,7 +10,6 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.address.model.record.exceptions.DuplicateRecordException;
 import seedu.address.model.record.exceptions.RecordNotFoundException;
-import seedu.address.model.task.exceptions.DuplicateTaskException;
 import seedu.address.model.task.exceptions.TaskNotFoundException;
 
 /**

--- a/src/main/java/seedu/address/model/record/UniqueRecordList.java
+++ b/src/main/java/seedu/address/model/record/UniqueRecordList.java
@@ -45,7 +45,7 @@ public class UniqueRecordList implements Iterable<Record> {
     public void add(Record toAdd) {
         requireNonNull(toAdd);
         if (contains(toAdd)) {
-            throw new DuplicateTaskException();
+            throw new DuplicateRecordException();
         }
         internalList.add(0, toAdd);
     }

--- a/src/main/java/seedu/address/model/record/UniqueRecordList.java
+++ b/src/main/java/seedu/address/model/record/UniqueRecordList.java
@@ -35,8 +35,7 @@ public class UniqueRecordList implements Iterable<Record> {
      */
     public boolean contains(Record toCheck) {
         requireNonNull(toCheck);
-        return false;
-        // return internalList.stream().anyMatch(toCheck::equals);
+        return internalList.stream().anyMatch(toCheck::equals);
     }
 
     /**
@@ -45,9 +44,6 @@ public class UniqueRecordList implements Iterable<Record> {
      */
     public void add(Record toAdd) {
         requireNonNull(toAdd);
-        if (contains(toAdd)) {
-            throw new DuplicateRecordException();
-        }
         internalList.add(0, toAdd);
     }
 

--- a/src/main/java/seedu/address/model/record/UniqueRecordList.java
+++ b/src/main/java/seedu/address/model/record/UniqueRecordList.java
@@ -31,10 +31,12 @@ public class UniqueRecordList implements Iterable<Record> {
 
     /**
      * Returns true if the list contains an equivalent Record as the given argument.
+     * At the moment, duplicates are allowed, all contains() checks return false.
      */
     public boolean contains(Record toCheck) {
         requireNonNull(toCheck);
-        return internalList.stream().anyMatch(toCheck::equals);
+        return false;
+        // return internalList.stream().anyMatch(toCheck::equals);
     }
 
     /**


### PR DESCRIPTION
### Overview
- New `RecordClear` command
- `Record` and `Teeth` now do not commit to `addressbook`
- Other minor fixes

#### The `RecordClear` command
- Requires to be in `GoTo` mode, where a patient is specified
- All records of the patient are deleted
- Does not commit to `addressbook`

#### `Record` and `Teeth` now do not commit to `addressbook`
- This prevents complications when undo-ing or redo-ing commands to and fro `GoTo` and `back` commands
- `Record` and `Teeth` commands are hence irreversible.

### Other minor fixes
- `AddressBookParser` now checks commands that can only run in the `GoTo` mode
- New message to users when running `GoTo` related commands outside of the mode
- Duplicate `records` are now saved as it would for unique records, but a message tells the user that a similar record already exists
- Record methods now correctly throw `DuplicateRecordException` when required, rather than the wrong Exception - `DuplicateTaskException`
- Thanks