### PR TITLE
[v1.4] Bugfix and small test

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -219,7 +219,7 @@ However, you can manage them manually with `open`, `save`, `import` and `export`
  +
 *When we mention "data", we mean the patients list and their respective records plus the task list.* +
 *.json files hold data that TeethHub can read. Use this to "save" or "load" your progress.* +
-*.pdf files hold data that are easier for people to read. Use this if you are printing out a physical copy.* +
+*.pdf files are easier for people to read. Use this if you are printing out a physical copy.* +
  +
 You can use `open` to open another .json file that you may have transferred over from another computer. +
  +

--- a/src/main/java/seedu/address/logic/commands/ExportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExportCommand.java
@@ -63,16 +63,12 @@ public class ExportCommand extends OutCommand {
         ModelManager tempModel = new ModelManager();
 
         tempModel.setAddressBook(model.getAddressBook());
-        ArrayList<Person> deleteList = new ArrayList<>();
+        tempModel.setPatientList(new ArrayList<>());
 
-        for (int i = 0; i < tempModel.getFilteredPersonList().size(); i++) {
-            if (!parsedIndex.contains(i)) {
-                deleteList.add(tempModel.getFilteredPersonList().get(i));
+        for (int i = 0; i < model.getFilteredPersonList().size(); i++) {
+            if (parsedIndex.contains(i)) {
+                tempModel.addPerson(model.getFilteredPersonList().get(i));
             }
-        }
-
-        for (Person personToDelete : deleteList) {
-            tempModel.deletePerson(personToDelete);
         }
 
         return tempModel;

--- a/src/main/java/seedu/address/logic/commands/ExportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExportCommand.java
@@ -11,7 +11,6 @@ import seedu.address.logic.CommandHistory;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
-import seedu.address.model.person.Person;
 import seedu.address.storage.ParsedInOut;
 
 /**

--- a/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
@@ -9,17 +9,12 @@ import java.util.HashSet;
 import java.util.List;
 
 import org.junit.Test;
+
 import seedu.address.logic.CommandHistory;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
-import seedu.address.model.datetime.DateOfBirth;
-import seedu.address.model.patient.Nric;
-import seedu.address.model.patient.Patient;
-import seedu.address.model.patient.Sex;
-import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
-import seedu.address.model.person.Phone;
 import seedu.address.storage.ParsedInOut;
 import seedu.address.testutil.TypicalPersons;
 
@@ -31,11 +26,10 @@ public class ExportCommandTest {
 
     private File file = new File("data" + File.separator + "test.json");
 
-    private void executeExportTest(String type, HashSet<Integer> range) throws Exception {
-        Model exportModel = new ModelManager();
-        Model expectedModel = new ModelManager();
-        Model actualModel = new ModelManager();
-
+    /**
+     * Exports the file with the patients specified in {@code HashSet<Integer< range}.
+     */
+    private void exportFile(Model exportModel, String type, HashSet<Integer> range) throws Exception {
         // Export the selected patients to {@code File file}
         exportModel.setPatientList(TypicalPersons.getTypicalPersons());
         exportModel.commitAddressBook();
@@ -45,12 +39,20 @@ public class ExportCommandTest {
         } catch (CommandException ce) {
             throw new CommandException(ce.getMessage());
         }
+    }
 
-        // Read the file that was just exported
-        OpenCommand openCommand = new OpenCommand(new ParsedInOut(file, type, range));
+    /**
+     * Reads the file specified by {@code File file}
+     */
+    private void readFile(Model actualModel, String type) throws Exception {
+        OpenCommand openCommand = new OpenCommand(new ParsedInOut(file, type));
         openCommand.execute(actualModel, new CommandHistory());
+    }
 
-        // Create list of expected patients
+    /**
+     * Adds the the patients specified in {@code HashSet<Integer< range} from exportModel to expectedModel.
+     */
+    private void createExpected(Model expectedModel, Model exportModel, HashSet<Integer> range) {
         List<Person> expectedPatients = new ArrayList<>();
         for (Integer i : range) {
             if (i < exportModel.getFilteredPersonList().size()) {
@@ -58,33 +60,46 @@ public class ExportCommandTest {
             }
         }
         expectedModel.setPatientList(expectedPatients);
+    }
+
+    /**
+     * Compares the person list in actualModel and expectedModel.
+     */
+    private void executeExportTest(String type, HashSet<Integer> range) throws Exception {
+        Model exportModel = new ModelManager();
+        Model expectedModel = new ModelManager();
+        Model actualModel = new ModelManager();
+
+        exportFile(exportModel, type, range);
+        readFile(actualModel, type);
+        createExpected(expectedModel, exportModel, range);
 
         assertEquals(expectedModel.getFilteredPersonList(), actualModel.getFilteredPersonList());
         file.delete();
     }
 
     @Test
-    public void executeExport_Simple() throws Exception {
+    public void executeExportSimple() throws Exception {
         executeExportTest("json", new HashSet<>(Arrays.asList(1)));
     }
 
     @Test
-    public void executeExport_1Comma2() throws Exception {
+    public void executeExport1Comma2() throws Exception {
         executeExportTest("json", new HashSet<>(Arrays.asList(1, 2)));
     }
 
     @Test
-    public void executeExport_1Comma5() throws Exception {
+    public void executeExport1Comma5() throws Exception {
         executeExportTest("json", new HashSet<>(Arrays.asList(1, 5)));
     }
 
     @Test
-    public void executeExport_1Dash5() throws Exception {
+    public void executeExport1Dash5() throws Exception {
         executeExportTest("json", new HashSet<>(Arrays.asList(1, 2, 3, 4, 5)));
     }
 
     @Test
-    public void executeExport_12Comma16() throws Exception {
+    public void executeExport12Comma16() throws Exception {
         executeExportTest("json", new HashSet<>(Arrays.asList(12, 16)));
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
@@ -1,0 +1,90 @@
+package seedu.address.logic.commands;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+
+import org.junit.Test;
+import seedu.address.logic.CommandHistory;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.datetime.DateOfBirth;
+import seedu.address.model.patient.Nric;
+import seedu.address.model.patient.Patient;
+import seedu.address.model.patient.Sex;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Phone;
+import seedu.address.storage.ParsedInOut;
+import seedu.address.testutil.TypicalPersons;
+
+/**
+ * These tests only check if ExportCommand is exporting .json properly, and not testing if user input is correct.
+ * For PDF testing, go to PdfSerializableAddressBookTest
+ */
+public class ExportCommandTest {
+
+    private File file = new File("data" + File.separator + "test.json");
+
+    private void executeExportTest(String type, HashSet<Integer> range) throws Exception {
+        Model exportModel = new ModelManager();
+        Model expectedModel = new ModelManager();
+        Model actualModel = new ModelManager();
+
+        // Export the selected patients to {@code File file}
+        exportModel.setPatientList(TypicalPersons.getTypicalPersons());
+        exportModel.commitAddressBook();
+        ExportCommand exportCommand = new ExportCommand(new ParsedInOut(file, type, range));
+        try {
+            exportCommand.execute(exportModel, new CommandHistory());
+        } catch (CommandException ce) {
+            throw new CommandException(ce.getMessage());
+        }
+
+        // Read the file that was just exported
+        OpenCommand openCommand = new OpenCommand(new ParsedInOut(file, type, range));
+        openCommand.execute(actualModel, new CommandHistory());
+
+        // Create list of expected patients
+        List<Person> expectedPatients = new ArrayList<>();
+        for (Integer i : range) {
+            if (i < exportModel.getFilteredPersonList().size()) {
+                expectedPatients.add(exportModel.getFilteredPersonList().get(i));
+            }
+        }
+        expectedModel.setPatientList(expectedPatients);
+
+        assertEquals(expectedModel.getFilteredPersonList(), actualModel.getFilteredPersonList());
+        file.delete();
+    }
+
+    @Test
+    public void executeExport_Simple() throws Exception {
+        executeExportTest("json", new HashSet<>(Arrays.asList(1)));
+    }
+
+    @Test
+    public void executeExport_1Comma2() throws Exception {
+        executeExportTest("json", new HashSet<>(Arrays.asList(1, 2)));
+    }
+
+    @Test
+    public void executeExport_1Comma5() throws Exception {
+        executeExportTest("json", new HashSet<>(Arrays.asList(1, 5)));
+    }
+
+    @Test
+    public void executeExport_1Dash5() throws Exception {
+        executeExportTest("json", new HashSet<>(Arrays.asList(1, 2, 3, 4, 5)));
+    }
+
+    @Test
+    public void executeExport_12Comma16() throws Exception {
+        executeExportTest("json", new HashSet<>(Arrays.asList(12, 16)));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/ExportCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ExportCommandParserTest.java
@@ -25,99 +25,54 @@ public class ExportCommandParserTest {
 
     private ExportCommandParser parser = new ExportCommandParser();
 
-    @Test
-    public void parse_validArgs_returnsExportCommandSimple() {
-        File test = new File("data" + File.separator + "test.json");
+    private void parse_validArgs(String filename, String type, String range, HashSet<Integer> expectedHash) {
+        File test = new File("data" + File.separator + filename + "." + type);
         try {
-            HashSet<Integer> expectedHash = new HashSet<>();
-            expectedHash.add(1 - 1);
-            ParsedInOut expected = new ParsedInOut(test, "json", expectedHash);
-            ParsedInOut actual = parser.parse(" test.json 1").getParsedInOut();
+            ParsedInOut expected;
+            if (range.equals("all")) {
+                expected = new ParsedInOut(test, type);
+            } else {
+                expected = new ParsedInOut(test, type, expectedHash);
+            }
+            ParsedInOut actual = parser.parse(" " + filename + "." + type + " " + range).getParsedInOut();
             assertEquals(actual.getFile(), expected.getFile());
             assertEquals(actual.getType(), expected.getType());
             assertEquals(actual.getArgIsAll(), expected.getArgIsAll());
-            HashSet<Integer> actualHash = actual.getParsedIndex();
-            for (Integer i : actualHash) {
-                assertTrue(expectedHash.contains(i));
+            if (range.equals("all")) {
+                assertEquals(actual.getParsedIndex().isEmpty(), expected.getParsedIndex().isEmpty());
+            } else {
+                HashSet<Integer> actualHash = actual.getParsedIndex();
+                for (Integer i : actualHash) {
+                    assertTrue(expectedHash.contains(i));
+                }
             }
         } catch (ParseException pe) {
             throw new IllegalArgumentException("Invalid userInput.", pe);
         }
+    }
+
+    @Test
+    public void parse_validArgs_returnsExportCommandSimple() {
+        parse_validArgs("test", "json", "1",
+                new HashSet<>(Arrays.asList(1 - 1)));
     }
 
     @Test
     public void parse_validArgs_returnsExportCommandPermittedSpecialCharacters() {
-        File test = new File("data" + File.separator + "test ! @ # $ % ^ & ( ) _ + - = { } [ ] ; ' , .json");
-        try {
-            HashSet<Integer> expectedHash = new HashSet<>();
-            expectedHash.add(1 - 1);
-            ParsedInOut expected = new ParsedInOut(test, "json", expectedHash);
-            ParsedInOut actual = parser.parse(" test ! @ # $ % ^ & ( ) _ + - = { } [ ] ; ' , .json 1")
-                .getParsedInOut();
-            assertEquals(actual.getFile(), expected.getFile());
-            assertEquals(actual.getType(), expected.getType());
-            assertEquals(actual.getArgIsAll(), expected.getArgIsAll());
-            HashSet<Integer> actualHash = actual.getParsedIndex();
-            for (Integer i : actualHash) {
-                assertTrue(expectedHash.contains(i));
-            }
-        } catch (ParseException pe) {
-            throw new IllegalArgumentException("Invalid userInput.", pe);
-        }
-    }
-
-    @Test
-    public void parse_invalidArgs_returnsExportCommandForbiddenSpecialCharacters() {
-        assertParseFailure(parser, " test < > : \" | ? *.json 1",
-            "Special characters such as\n> < : \" | ? *\nare not allowed."
-                + "\n" + ExportCommand.MESSAGE_USAGE);
+        parse_validArgs("test ! @ # $ % ^ & ( ) _ + - = { } [ ] ; ' , .json", "json", "0",
+                new HashSet<>(Arrays.asList(0 - 1)));
     }
 
     @Test
     public void parse_validArgs_returnsExportCommandPdf() {
-        File test = new File("data" + File.separator + "test.pdf");
-        try {
-            HashSet<Integer> expectedHash = new HashSet<>();
-            expectedHash.add(1 - 1);
-            ParsedInOut expected = new ParsedInOut(test, "pdf", expectedHash);
-            ParsedInOut actual = parser.parse(" test.pdf 1").getParsedInOut();
-            assertEquals(actual.getFile(), expected.getFile());
-            assertEquals(actual.getType(), expected.getType());
-            assertEquals(actual.getArgIsAll(), expected.getArgIsAll());
-            HashSet<Integer> actualHash = actual.getParsedIndex();
-            for (Integer i : actualHash) {
-                assertTrue(expectedHash.contains(i));
-            }
-        } catch (ParseException pe) {
-            throw new IllegalArgumentException("Invalid userInput.", pe);
-        }
+        parse_validArgs("test", "pdf", "1",
+                new HashSet<>(Arrays.asList(1 - 1)));
     }
 
     @Test
     public void parse_validArgs_returnsExportCommandIndexOutOfBound() {
-        File test = new File("data" + File.separator + "test.json");
-        try {
-            HashSet<Integer> expectedHash = new HashSet<>();
-            expectedHash.add(0 - 1);
-            ParsedInOut expected = new ParsedInOut(test, "json", expectedHash);
-            ParsedInOut actual = parser.parse(" test.json 0").getParsedInOut();
-            assertEquals(actual.getFile(), expected.getFile());
-            assertEquals(actual.getType(), expected.getType());
-            assertEquals(actual.getArgIsAll(), expected.getArgIsAll());
-            HashSet<Integer> actualHash = actual.getParsedIndex();
-            for (Integer i : actualHash) {
-                assertTrue(expectedHash.contains(i));
-            }
-        } catch (ParseException pe) {
-            throw new IllegalArgumentException("Invalid userInput.", pe);
-        }
-    }
-
-    @Test
-    public void parse_invalidArgs_throwsParseException() {
-        File test = new File("data" + File.separator + "test.pdf");
-        assertParseFailure(parser, " records.txt 1",
-            ParserUtil.MESSAGE_NOT_JSON_OR_PDF + "\n" + ExportCommand.MESSAGE_USAGE);
+        parse_validArgs("test", "json", "0",
+                new HashSet<>(Arrays.asList(0 - 1)));
     }
 
     @Test
@@ -206,108 +161,74 @@ public class ExportCommandParserTest {
 
     @Test
     public void parse_validArgs_returnsExportCommand1Comma3() {
-        File test = new File("data" + File.separator + "test.json");
-        try {
-            HashSet<Integer> expectedHash = new HashSet<>(Arrays.asList(1 - 1, 3 - 1));
-            ParsedInOut expected = new ParsedInOut(test, "json", expectedHash);
-            ParsedInOut actual = parser.parse(" test.json 1,3").getParsedInOut();
-            assertEquals(actual.getFile(), expected.getFile());
-            assertEquals(actual.getType(), expected.getType());
-            assertEquals(actual.getArgIsAll(), expected.getArgIsAll());
-            HashSet<Integer> actualHash = actual.getParsedIndex();
-            for (Integer i : actualHash) {
-                assertTrue(expectedHash.contains(i));
-            }
-        } catch (ParseException pe) {
-            throw new IllegalArgumentException("Invalid userInput.", pe);
-        }
+        parse_validArgs("test", "json", "1,3",
+                new HashSet<>(Arrays.asList(1 - 1, 3 - 1)));
     }
 
     @Test
     public void parse_validArgs_returnsExportCommand1Dash3() {
-        File test = new File("data" + File.separator + "test.json");
-        try {
-            HashSet<Integer> expectedHash = new HashSet<>(Arrays.asList(1 - 1, 2 - 1, 3 - 1));
-            ParsedInOut expected = new ParsedInOut(test, "json", expectedHash);
-            ParsedInOut actual = parser.parse(" test.json 1-3").getParsedInOut();
-            assertEquals(actual.getFile(), expected.getFile());
-            assertEquals(actual.getType(), expected.getType());
-            assertEquals(actual.getArgIsAll(), expected.getArgIsAll());
-            HashSet<Integer> actualHash = actual.getParsedIndex();
-            for (Integer i : actualHash) {
-                assertTrue(expectedHash.contains(i));
-            }
-        } catch (ParseException pe) {
-            throw new IllegalArgumentException("Invalid userInput.", pe);
-        }
+        parse_validArgs("test", "json", "1-3",
+                new HashSet<>(Arrays.asList(1 - 1, 2 - 1, 3 - 1)));
     }
 
     @Test
     public void parse_validArgs_returnsExportCommand1Comma3Comma5() {
-        File test = new File("data" + File.separator + "test.json");
-        try {
-            HashSet<Integer> expectedHash = new HashSet<>(Arrays.asList(1 - 1, 3 - 1, 5 - 1));
-            ParsedInOut expected = new ParsedInOut(test, "json", expectedHash);
-            ParsedInOut actual = parser.parse(" test.json 1,3,5").getParsedInOut();
-            assertEquals(actual.getFile(), expected.getFile());
-            assertEquals(actual.getType(), expected.getType());
-            assertEquals(actual.getArgIsAll(), expected.getArgIsAll());
-            HashSet<Integer> actualHash = actual.getParsedIndex();
-            for (Integer i : actualHash) {
-                assertTrue(expectedHash.contains(i));
-            }
-        } catch (ParseException pe) {
-            throw new IllegalArgumentException("Invalid userInput.", pe);
-        }
+        parse_validArgs("test", "json", "1,3,5",
+                new HashSet<>(Arrays.asList(1 - 1, 3 - 1, 5 - 1)));
     }
+
 
     @Test
     public void parse_validArgs_returnsExportCommand1Comma3Dash5() {
-        File test = new File("data" + File.separator + "test.json");
-        try {
-            HashSet<Integer> expectedHash = new HashSet<>(Arrays.asList(1 - 1, 3 - 1, 4 - 1, 5 - 1));
-            ParsedInOut expected = new ParsedInOut(test, "json", expectedHash);
-            ParsedInOut actual = parser.parse(" test.json 1,3-5").getParsedInOut();
-            assertEquals(actual.getFile(), expected.getFile());
-            assertEquals(actual.getType(), expected.getType());
-            assertEquals(actual.getArgIsAll(), expected.getArgIsAll());
-            HashSet<Integer> actualHash = actual.getParsedIndex();
-            for (Integer i : actualHash) {
-                assertTrue(expectedHash.contains(i));
-            }
-        } catch (ParseException pe) {
-            throw new IllegalArgumentException("Invalid userInput.", pe);
-        }
+        parse_validArgs("test", "json", "1,3-5",
+                new HashSet<>(Arrays.asList(1 - 1, 3 - 1, 4 - 1, 5 - 1)));
     }
 
     @Test
     public void parse_validArgs_returnsExportCommandAll() {
-        File test = new File("data" + File.separator + "test.json");
-        try {
-            ParsedInOut expected = new ParsedInOut(test, "json");
-            ParsedInOut actual = parser.parse(" test.json all").getParsedInOut();
-            assertEquals(actual.getFile(), expected.getFile());
-            assertEquals(actual.getType(), expected.getType());
-            assertEquals(actual.getArgIsAll(), expected.getArgIsAll());
-            assertEquals(actual.getParsedIndex().isEmpty(), expected.getParsedIndex().isEmpty());
-        } catch (ParseException pe) {
-            throw new IllegalArgumentException("Invalid userInput.", pe);
-        }
+        parse_validArgs("test", "json", "all", new HashSet<>());
     }
 
 
     @Test
     public void parse_validArgs_returnsExportCommandEmptyFilename() {
-        File test = new File("data" + File.separator + ".json");
-        try {
-            ParsedInOut expected = new ParsedInOut(test, "json");
-            ParsedInOut actual = parser.parse(" .json all").getParsedInOut();
-            assertEquals(actual.getFile(), expected.getFile());
-            assertEquals(actual.getType(), expected.getType());
-            assertEquals(actual.getArgIsAll(), expected.getArgIsAll());
-            assertEquals(actual.getParsedIndex().isEmpty(), expected.getParsedIndex().isEmpty());
-        } catch (ParseException pe) {
-            throw new IllegalArgumentException("Invalid userInput.", pe);
-        }
+        parse_validArgs("", "json", "all", new HashSet<>());
+    }
+
+    @Test
+    public void parse_invalidArgs_ExportCommandForbiddenSpecialCharacters() {
+        assertParseFailure(parser, " test < > : \" | ? *.json 1",
+                "Special characters such as\n> < : \" | ? *\nare not allowed."
+                        + "\n" + ExportCommand.MESSAGE_USAGE);
+    }
+
+    @Test
+    public void parse_invalidArgs_NotJsonOrPdf() {
+        assertParseFailure(parser, " records.txt 1",
+                ParserUtil.MESSAGE_NOT_JSON_OR_PDF + "\n" + ExportCommand.MESSAGE_USAGE);
+    }
+
+    @Test
+    public void parse_invalidArgs_DoubleDash() {
+        assertParseFailure(parser, " records.json 1--3",
+                ParserUtil.MESSAGE_INVALID_INDEX_RANGE + "\n" + ExportCommand.MESSAGE_USAGE);
+    }
+
+    @Test
+    public void parse_invalidArgs_DoubleComma() {
+        assertParseFailure(parser, " records.json 1,,3",
+                ParserUtil.MESSAGE_INVALID_INDEX_RANGE + "\n" + ExportCommand.MESSAGE_USAGE);
+    }
+
+    @Test
+    public void parse_invalidArgs_CommaDashMash() {
+        assertParseFailure(parser, " records.json 1,-,3",
+                ParserUtil.MESSAGE_INVALID_INDEX_RANGE + "\n" + ExportCommand.MESSAGE_USAGE);
+    }
+
+    @Test
+    public void parse_invalidArgs_DashChain() {
+        assertParseFailure(parser, " records.json 1-3-5",
+                ParserUtil.MESSAGE_INVALID_INDEX_RANGE + "\n" + ExportCommand.MESSAGE_USAGE);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/ExportCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ExportCommandParserTest.java
@@ -25,6 +25,13 @@ public class ExportCommandParserTest {
 
     private ExportCommandParser parser = new ExportCommandParser();
 
+    /**
+     * Parses the given filename, type and range, then compares them to the expected result.
+     * @param filename The file name
+     * @param type The file type
+     * @param range The index range to parse
+     * @param expectedHash The expected parsed index range
+     */
     private void parse_validArgs(String filename, String type, String range, HashSet<Integer> expectedHash) {
         File test = new File("data" + File.separator + filename + "." + type);
         try {
@@ -118,7 +125,7 @@ public class ExportCommandParserTest {
     @Test
     public void parse_validArgs_returnsExportCommandBothSlash() {
         File test = new File("data" + File.separator + File.separator
-            + "testfolder" + File.separator + "test.json");
+                + "testfolder" + File.separator + "test.json");
         try {
             HashSet<Integer> expectedHash = new HashSet<>();
             expectedHash.add(1 - 1);
@@ -139,9 +146,9 @@ public class ExportCommandParserTest {
     @Test
     public void parse_validArgs_returnsExportCommandMultipleSlash() {
         File test = new File("data" + File.separator + "testfolder" + File.separator + File.separator
-            + File.separator + File.separator + File.separator + File.separator + File.separator + File.separator
-            + File.separator + File.separator + File.separator + File.separator + File.separator + File.separator
-            + File.separator + File.separator + File.separator + File.separator + File.separator + "test.json");
+                + File.separator + File.separator + File.separator + File.separator + File.separator + File.separator
+                + File.separator + File.separator + File.separator + File.separator + File.separator + File.separator
+                + File.separator + File.separator + File.separator + File.separator + File.separator + "test.json");
         try {
             HashSet<Integer> expectedHash = new HashSet<>();
             expectedHash.add(1 - 1);
@@ -196,38 +203,38 @@ public class ExportCommandParserTest {
     }
 
     @Test
-    public void parse_invalidArgs_ExportCommandForbiddenSpecialCharacters() {
+    public void parse_invalidArgsExportCommandForbiddenSpecialCharacters() {
         assertParseFailure(parser, " test < > : \" | ? *.json 1",
                 "Special characters such as\n> < : \" | ? *\nare not allowed."
                         + "\n" + ExportCommand.MESSAGE_USAGE);
     }
 
     @Test
-    public void parse_invalidArgs_NotJsonOrPdf() {
+    public void parse_invalidArgsNotJsonOrPdf() {
         assertParseFailure(parser, " records.txt 1",
                 ParserUtil.MESSAGE_NOT_JSON_OR_PDF + "\n" + ExportCommand.MESSAGE_USAGE);
     }
 
     @Test
-    public void parse_invalidArgs_DoubleDash() {
+    public void parse_invalidArgsDoubleDash() {
         assertParseFailure(parser, " records.json 1--3",
                 ParserUtil.MESSAGE_INVALID_INDEX_RANGE + "\n" + ExportCommand.MESSAGE_USAGE);
     }
 
     @Test
-    public void parse_invalidArgs_DoubleComma() {
+    public void parse_invalidArgsDoubleComma() {
         assertParseFailure(parser, " records.json 1,,3",
                 ParserUtil.MESSAGE_INVALID_INDEX_RANGE + "\n" + ExportCommand.MESSAGE_USAGE);
     }
 
     @Test
-    public void parse_invalidArgs_CommaDashMash() {
+    public void parse_invalidArgsCommaDashMash() {
         assertParseFailure(parser, " records.json 1,-,3",
                 ParserUtil.MESSAGE_INVALID_INDEX_RANGE + "\n" + ExportCommand.MESSAGE_USAGE);
     }
 
     @Test
-    public void parse_invalidArgs_DashChain() {
+    public void parse_invalidArgsDashChain() {
         assertParseFailure(parser, " records.json 1-3-5",
                 ParserUtil.MESSAGE_INVALID_INDEX_RANGE + "\n" + ExportCommand.MESSAGE_USAGE);
     }


### PR DESCRIPTION
Pre-bugfixed ExportCommand: Failed to add correctly parsed persons with the same name and with double digit index at the same time.
Post bugfixed ExportCommand: Fixed above problem. Implementation of fix also reduced unnecessary steps resulting in better performance.

Refactored ExportCommandParserTest.java
Added ExportCommandTest.java 